### PR TITLE
updated the default ossBucketKey

### DIFF
--- a/server/forge.js
+++ b/server/forge.js
@@ -42,7 +42,7 @@ router.get('/forge/oauth/token', function (req, res) {
   })
 });
 
-var ossBucketKey = process.env.FORGE_BUCKET || 'navigationsample3d2d';
+var ossBucketKey = process.env.FORGE_BUCKET || 'someveryuniquename2d3d';//'navigationsample3d2d';
 
 router.get('/forge/models', function (req, res) {
   var t = new token();


### PR DESCRIPTION
Some users reports problems in using this sample, and it turns out that the 'navigationsample3d2d' string used as default ossBucketKey is the cause. The ossBucketKey  has to be unique, but apparently the 'navigationsample3d2d' one already exist for all users?